### PR TITLE
calico: extract a minimal calico client to different pkg

### DIFF
--- a/cmd/remesherd/root.go
+++ b/cmd/remesherd/root.go
@@ -13,7 +13,8 @@ import (
 	"syscall"
 	"time"
 
-	calicoclientv3 "github.com/projectcalico/libcalico-go/lib/clientv3"
+	"github.com/tsuru/remesher/pkg/calico"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -101,11 +102,10 @@ var rootCmd = &cobra.Command{
 		if err != nil {
 			log.Fatalf("Error creating kubernetes client: %v", err)
 		}
-		calicoClient, err := calicoclientv3.NewFromEnv()
+		calicoClient, err := calico.NewBGPPeerClient()
 		if err != nil {
 			log.Fatalf("Error creating calico client: %v", err)
 		}
-
 		go servePrometheusMetrics(viper.GetString("metrics-port"), stopCh, log)
 		err = controller.Start(controller.Config{
 			KubeClient:        kubeClient,

--- a/cmd/remesherd/root.go
+++ b/cmd/remesherd/root.go
@@ -51,6 +51,7 @@ func init() {
 			"before it stops leading. This must be less than or equal to the lease duration. ")
 	rootCmd.PersistentFlags().Duration("leader-elect.retry-period", time.Second*5,
 		"The duration the clients should wait between attempting acquisition and renewal of a leadership.")
+	rootCmd.PersistentFlags().Duration("calico-timeout", time.Second*5, "The timeout duration of calico operations.")
 }
 
 func initConfig() {
@@ -102,7 +103,7 @@ var rootCmd = &cobra.Command{
 		if err != nil {
 			log.Fatalf("Error creating kubernetes client: %v", err)
 		}
-		calicoClient, err := calico.NewBGPPeerClient(logrus.NewEntry(log), time.Second*5)
+		calicoClient, err := calico.NewBGPPeerClient(logrus.NewEntry(log), time.Second*5, prometheus.DefaultRegisterer)
 		if err != nil {
 			log.Fatalf("Error creating calico client: %v", err)
 		}

--- a/cmd/remesherd/root.go
+++ b/cmd/remesherd/root.go
@@ -103,7 +103,7 @@ var rootCmd = &cobra.Command{
 		if err != nil {
 			log.Fatalf("Error creating kubernetes client: %v", err)
 		}
-		calicoClient, err := calico.NewBGPPeerClient(logrus.NewEntry(log), time.Second*5, prometheus.DefaultRegisterer)
+		calicoClient, err := calico.NewBGPPeerClient(logrus.NewEntry(log), viper.GetDuration("calico-timeout"), prometheus.DefaultRegisterer)
 		if err != nil {
 			log.Fatalf("Error creating calico client: %v", err)
 		}

--- a/cmd/remesherd/root.go
+++ b/cmd/remesherd/root.go
@@ -102,7 +102,7 @@ var rootCmd = &cobra.Command{
 		if err != nil {
 			log.Fatalf("Error creating kubernetes client: %v", err)
 		}
-		calicoClient, err := calico.NewBGPPeerClient()
+		calicoClient, err := calico.NewBGPPeerClient(logrus.NewEntry(log), time.Second*5)
 		if err != nil {
 			log.Fatalf("Error creating calico client: %v", err)
 		}

--- a/pkg/calico/calico.go
+++ b/pkg/calico/calico.go
@@ -2,50 +2,66 @@ package calico
 
 import (
 	"context"
+	"time"
+
+	"github.com/sirupsen/logrus"
 
 	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
 	calicoclientv3 "github.com/projectcalico/libcalico-go/lib/clientv3"
+	calicoerrors "github.com/projectcalico/libcalico-go/lib/errors"
 	"github.com/projectcalico/libcalico-go/lib/options"
-	"github.com/projectcalico/libcalico-go/lib/watch"
 )
 
-var _ calicoclientv3.BGPPeerInterface = &BGPPeerClient{}
-
-// BGPPeerClient is a wrapper around the calicoclientv3.BGPPeerInterface that provides metrics
-type BGPPeerClient struct {
-	calicoClient calicoclientv3.Interface
+// BGPPeerInterface is a minimal interface that describe the basic operations performed by a BGPPeerClient
+type BGPPeerInterface interface {
+	Create(peer *apiv3.BGPPeer) error
+	Delete(name string) error
+	List() (*apiv3.BGPPeerList, error)
 }
 
-func NewBGPPeerClient() (*BGPPeerClient, error) {
+// BGPPeerClient is a BGPPeerInterface implements automatic timeouts
+type bgpPeerClient struct {
+	calicoClient calicoclientv3.Interface
+	logger       *logrus.Entry
+
+	timeout time.Duration
+}
+
+func NewBGPPeerClient(logger *logrus.Entry, timeout time.Duration) (BGPPeerInterface, error) {
 	calicoClient, err := calicoclientv3.NewFromEnv()
 	if err != nil {
 		return nil, err
 	}
-	return &BGPPeerClient{
+	return &bgpPeerClient{
 		calicoClient: calicoClient,
+		timeout:      timeout,
 	}, nil
 }
 
-func (c *BGPPeerClient) Create(ctx context.Context, res *apiv3.BGPPeer, opts options.SetOptions) (*apiv3.BGPPeer, error) {
-	return c.calicoClient.BGPPeers().Create(ctx, res, opts)
+func (c *bgpPeerClient) Create(peer *apiv3.BGPPeer) error {
+	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
+	defer cancel()
+	_, err := c.calicoClient.BGPPeers().Create(ctx, peer, options.SetOptions{})
+	if _, ok := err.(calicoerrors.ErrorResourceAlreadyExists); ok {
+		c.logger.Infof("ignoring error creating bgpPeer %v: %v", peer.Name, err)
+		return nil
+	}
+	return err
 }
 
-func (c *BGPPeerClient) Update(ctx context.Context, res *apiv3.BGPPeer, opts options.SetOptions) (*apiv3.BGPPeer, error) {
-	return c.calicoClient.BGPPeers().Update(ctx, res, opts)
+func (c *bgpPeerClient) Delete(name string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
+	defer cancel()
+	_, err := c.calicoClient.BGPPeers().Delete(ctx, name, options.DeleteOptions{})
+	if _, ok := err.(calicoerrors.ErrorResourceDoesNotExist); ok {
+		c.logger.Infof("ignoring error deleting bgpPeer %v: %v", name, err)
+		return nil
+	}
+	return err
 }
 
-func (c *BGPPeerClient) Delete(ctx context.Context, name string, opts options.DeleteOptions) (*apiv3.BGPPeer, error) {
-	return c.calicoClient.BGPPeers().Delete(ctx, name, opts)
-}
-
-func (c *BGPPeerClient) Get(ctx context.Context, name string, opts options.GetOptions) (*apiv3.BGPPeer, error) {
-	return c.calicoClient.BGPPeers().Get(ctx, name, opts)
-}
-
-func (c *BGPPeerClient) List(ctx context.Context, opts options.ListOptions) (*apiv3.BGPPeerList, error) {
-	return c.calicoClient.BGPPeers().List(ctx, opts)
-}
-
-func (c *BGPPeerClient) Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error) {
-	return c.calicoClient.BGPPeers().Watch(ctx, opts)
+func (c *bgpPeerClient) List() (*apiv3.BGPPeerList, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
+	defer cancel()
+	return c.calicoClient.BGPPeers().List(ctx, options.ListOptions{})
 }

--- a/pkg/calico/calico.go
+++ b/pkg/calico/calico.go
@@ -1,0 +1,51 @@
+package calico
+
+import (
+	"context"
+
+	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
+	calicoclientv3 "github.com/projectcalico/libcalico-go/lib/clientv3"
+	"github.com/projectcalico/libcalico-go/lib/options"
+	"github.com/projectcalico/libcalico-go/lib/watch"
+)
+
+var _ calicoclientv3.BGPPeerInterface = &BGPPeerClient{}
+
+// BGPPeerClient is a wrapper around the calicoclientv3.BGPPeerInterface that provides metrics
+type BGPPeerClient struct {
+	calicoClient calicoclientv3.Interface
+}
+
+func NewBGPPeerClient() (*BGPPeerClient, error) {
+	calicoClient, err := calicoclientv3.NewFromEnv()
+	if err != nil {
+		return nil, err
+	}
+	return &BGPPeerClient{
+		calicoClient: calicoClient,
+	}, nil
+}
+
+func (c *BGPPeerClient) Create(ctx context.Context, res *apiv3.BGPPeer, opts options.SetOptions) (*apiv3.BGPPeer, error) {
+	return c.calicoClient.BGPPeers().Create(ctx, res, opts)
+}
+
+func (c *BGPPeerClient) Update(ctx context.Context, res *apiv3.BGPPeer, opts options.SetOptions) (*apiv3.BGPPeer, error) {
+	return c.calicoClient.BGPPeers().Update(ctx, res, opts)
+}
+
+func (c *BGPPeerClient) Delete(ctx context.Context, name string, opts options.DeleteOptions) (*apiv3.BGPPeer, error) {
+	return c.calicoClient.BGPPeers().Delete(ctx, name, opts)
+}
+
+func (c *BGPPeerClient) Get(ctx context.Context, name string, opts options.GetOptions) (*apiv3.BGPPeer, error) {
+	return c.calicoClient.BGPPeers().Get(ctx, name, opts)
+}
+
+func (c *BGPPeerClient) List(ctx context.Context, opts options.ListOptions) (*apiv3.BGPPeerList, error) {
+	return c.calicoClient.BGPPeers().List(ctx, opts)
+}
+
+func (c *BGPPeerClient) Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error) {
+	return c.calicoClient.BGPPeers().Watch(ctx, opts)
+}

--- a/pkg/calico/calico.go
+++ b/pkg/calico/calico.go
@@ -10,6 +10,13 @@ import (
 	calicoclientv3 "github.com/projectcalico/libcalico-go/lib/clientv3"
 	calicoerrors "github.com/projectcalico/libcalico-go/lib/errors"
 	"github.com/projectcalico/libcalico-go/lib/options"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	opCreate = "create"
+	opList   = "list"
+	opDelete = "delete"
 )
 
 // BGPPeerInterface is a minimal interface that describe the basic operations performed by a BGPPeerClient
@@ -19,29 +26,55 @@ type BGPPeerInterface interface {
 	List() (*apiv3.BGPPeerList, error)
 }
 
-// BGPPeerClient is a BGPPeerInterface implements automatic timeouts
+// BGPPeerClient is a BGPPeerInterface implements automatic timeouts and metrics
 type bgpPeerClient struct {
 	calicoClient calicoclientv3.Interface
 	logger       *logrus.Entry
 
 	timeout time.Duration
+
+	latencies *prometheus.HistogramVec
+	errors    *prometheus.CounterVec
 }
 
-func NewBGPPeerClient(logger *logrus.Entry, timeout time.Duration) (BGPPeerInterface, error) {
+// NewBGPPeerClient constructs BGPPeerInterface instance registering its metrics and timeouts
+func NewBGPPeerClient(logger *logrus.Entry, timeout time.Duration, metricsRegisterer prometheus.Registerer) (BGPPeerInterface, error) {
 	calicoClient, err := calicoclientv3.NewFromEnv()
 	if err != nil {
+		return nil, err
+	}
+	latencies := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "remesher_calico_operations_duration",
+		Help: "The duration of calico requests.",
+	}, []string{"operation"})
+	if err := metricsRegisterer.Register(latencies); err != nil {
+		return nil, err
+	}
+	errors := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "remesher_calico_errors_total",
+		Help: "The total number of errors.",
+	}, []string{"operation"})
+	if err := metricsRegisterer.Register(errors); err != nil {
 		return nil, err
 	}
 	return &bgpPeerClient{
 		calicoClient: calicoClient,
 		timeout:      timeout,
+		latencies:    latencies,
+		errors:       errors,
 	}, nil
 }
 
-func (c *bgpPeerClient) Create(peer *apiv3.BGPPeer) error {
+func (c *bgpPeerClient) Create(peer *apiv3.BGPPeer) (err error) {
+	defer func(begin time.Time, op string) {
+		c.latencies.WithLabelValues(op).Observe(time.Since(begin).Seconds())
+		if err != nil {
+			c.errors.WithLabelValues(op).Inc()
+		}
+	}(time.Now(), opCreate)
 	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
 	defer cancel()
-	_, err := c.calicoClient.BGPPeers().Create(ctx, peer, options.SetOptions{})
+	_, err = c.calicoClient.BGPPeers().Create(ctx, peer, options.SetOptions{})
 	if _, ok := err.(calicoerrors.ErrorResourceAlreadyExists); ok {
 		c.logger.Infof("ignoring error creating bgpPeer %v: %v", peer.Name, err)
 		return nil
@@ -49,10 +82,16 @@ func (c *bgpPeerClient) Create(peer *apiv3.BGPPeer) error {
 	return err
 }
 
-func (c *bgpPeerClient) Delete(name string) error {
+func (c *bgpPeerClient) Delete(name string) (err error) {
+	defer func(begin time.Time, op string) {
+		c.latencies.WithLabelValues(op).Observe(time.Since(begin).Seconds())
+		if err != nil {
+			c.errors.WithLabelValues(op).Inc()
+		}
+	}(time.Now(), opDelete)
 	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
 	defer cancel()
-	_, err := c.calicoClient.BGPPeers().Delete(ctx, name, options.DeleteOptions{})
+	_, err = c.calicoClient.BGPPeers().Delete(ctx, name, options.DeleteOptions{})
 	if _, ok := err.(calicoerrors.ErrorResourceDoesNotExist); ok {
 		c.logger.Infof("ignoring error deleting bgpPeer %v: %v", name, err)
 		return nil
@@ -60,7 +99,13 @@ func (c *bgpPeerClient) Delete(name string) error {
 	return err
 }
 
-func (c *bgpPeerClient) List() (*apiv3.BGPPeerList, error) {
+func (c *bgpPeerClient) List() (list *apiv3.BGPPeerList, err error) {
+	defer func(begin time.Time, op string) {
+		c.latencies.WithLabelValues(op).Observe(time.Since(begin).Seconds())
+		if err != nil {
+			c.errors.WithLabelValues(op).Inc()
+		}
+	}(time.Now(), opList)
 	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
 	defer cancel()
 	return c.calicoClient.BGPPeers().List(ctx, options.ListOptions{})

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -40,7 +40,6 @@ const (
 	asNumber              = client.GlobalDefaultASNumber
 	remesherManagedLabel  = "remesher.tsuru.io/managed"
 	remesherPeerNodeLabel = "remesher.tsuru.io/peer-node"
-	calicoTimeout         = time.Second * 5
 
 	// BGPPeersSyncFailed is the reason used on events to denote a failed sync
 	BGPPeersSyncFailed = "BGPPeersSyncFailed"

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -188,8 +188,9 @@ func newController(kubeclientset kubernetes.Interface,
 	controller.metricsRegisterer = metricsRegistry
 	controller.workqueueDuration = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
-			Name: "remesher_controller_process_duration",
-			Help: "The duration of the item processing in seconds.",
+			Name:    "remesher_controller_process_duration",
+			Help:    "The duration of the item processing in seconds.",
+			Buckets: prometheus.LinearBuckets(1, 2, 30),
 		},
 	)
 	controller.errorsCounter = prometheus.NewCounter(


### PR DESCRIPTION
This will facilitate adding tests, instrumentation and
perhaps caching in the future.