### PR TITLE
controller: use default namespace for event recorder

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -92,7 +92,7 @@ type Config struct {
 func Start(c Config, stopCh <-chan struct{}) error {
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartLogging(c.Logger.Infof)
-	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: c.KubeClient.CoreV1().Events(c.Namespace)})
+	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: c.KubeClient.CoreV1().Events("")})
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: controllerAgentName})
 
 	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(c.KubeClient, c.ResyncInterval)


### PR DESCRIPTION
Prior to this change, we were creating a event recorder on a given
namespace. When registering events for node, the following would happen:

Unable to write event: 'can't create an event with namespace 'default'
in namespace 'kube-system'' (may retry after sleeping)

This change modifies the event recorder to be created using the default
namespace, which will allow events to be recorder on that namespace.