### PR TITLE
controller: adds standalone resync loop

### DIFF
--- a/cmd/remesherd/root.go
+++ b/cmd/remesherd/root.go
@@ -137,6 +137,8 @@ func setupSignalHandler() (stopCh <-chan struct{}) {
 	go func() {
 		<-c
 		close(stop)
+		<-c
+		os.Exit(1)
 	}()
 
 	return stop


### PR DESCRIPTION
Prior to this change, all Updates would trigger the processing of a given
node. Since every kubelet status change triggers a Node update, this
basically means that, for a large cluster, the controller would keep
running its reconcile loop wasting CPU.

This change makes that a Node is only added to the workqueue when one of
its interesting labels changes (neighborhood, master or global). This
change also introduces a standalone resync loop that adds events for every
node every resync period, so that we don't lose events.